### PR TITLE
Corrected filename generation before saving in Dropbox

### DIFF
--- a/DropboxSync.BLL/Services/DropboxService.cs
+++ b/DropboxSync.BLL/Services/DropboxService.cs
@@ -251,7 +251,7 @@ namespace DropboxSync.BLL.Services
                 return dropboxSaved;
             }
 
-            string dropboxFileName = GenerateDropboxFileName(dossierName, createdAt);
+            string dropboxFileName = GenerateDropboxFileName(fileName, createdAt);
             string destinationPath = GenerateFileDestinationPath(dropboxDestinationPath, dropboxFileName);
 
             FileMetadata? dropboxUploadResult = await _dropboxClient.Files.UploadAsync(new UploadArg(destinationPath),


### PR DESCRIPTION
## Description

When a dossier was closed and sent to Dropbox its extension was missing. It was due to an error during Dropbox file name generation.

`string dropboxFileName = GenerateDropboxFileName(dossierName, createdAt);` The parameter `dossierName` was incorrect and has been chanegd to the correct file name like this : `string dropboxFileName = GenerateDropboxFileName(fileName, createdAt);`

Fixes #17 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

This fix has been tested by closing a dossier and verifying in Dropbox the file name

- [x] Close dossier

**Test Configuration**:
* Firmware version:
* Hardware:
* Toolchain: VSCode
* SDK: .NET 6

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
