### PR TITLE
Feat/zip stored in archive

### DIFF
--- a/DropboxSync.BLL/Services/DropboxService.cs
+++ b/DropboxSync.BLL/Services/DropboxService.cs
@@ -241,7 +241,7 @@ namespace DropboxSync.BLL.Services
 
             DropboxSavedFile? dropboxSaved = null;
 
-            string dropboxDestinationPath = GenerateFileDestinationPath(GeneratedFolderPath(createdAt.Year, FileTypes.Dossiers), dossierName);
+            string dropboxDestinationPath = GenerateArchivePath();
 
             string? dropboxFolderPath = await VerifyFolderExist(dropboxDestinationPath, true);
 
@@ -655,6 +655,19 @@ namespace DropboxSync.BLL.Services
             if (string.IsNullOrEmpty(fileName)) throw new ArgumentNullException(nameof(fileName));
 
             return string.Join('/', destinationFolderPath, fileName);
+        }
+
+        /// <summary>
+        /// Generate a Unix file path to the archives in the next format
+        /// <code>
+        /// /ROOT_FOLDER/ARCHIVES
+        /// </code>
+        /// </summary>
+        /// <param name="filename"></param>
+        /// <returns></returns>
+        private string GenerateArchivePath()
+        {
+            return string.Join('/', ROOT_FOLDER, "ARCHIVES");
         }
 
         /// <summary>


### PR DESCRIPTION
## Description

Simply generated a new destination path "/ROOT_FOLDER/ARCHIVE" in which the ZIP file is saved the same way it was saved  : "CREATION_DATETIME-FILE_NAME".

Fixes #19 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [x] Closing dossier in the ERP

**Test Configuration**:
* Firmware version: Ubuntu 22.04 LTS
* Hardware:
* Toolchain: VSCode
* SDK: .NET 6

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
