### PR TITLE
Feat/expense tag directory

### DIFF
--- a/DropboxSync.BLL/IServices/IDropboxService.cs
+++ b/DropboxSync.BLL/IServices/IDropboxService.cs
@@ -16,7 +16,7 @@ namespace DropboxSync.BLL.IServices
         Task<bool> DeleteDossierAsync(string dossierName, DateTime createdAt);
         Task<DropboxSavedFile?> SaveDossierAsync(string dossierName, string fileName, string dossierRelativePath, DateTime createdAt);
         Task<DropboxMovedFile?> MoveFileAsync(string dropboxFileId, DateTime fileCreationDate, FileTypes movingFilesType, bool isProcess,
-            string? dossierName = null);
+            string? dossierName = null, string? label = null);
         Task<bool> DeleteFile(string dropboxId);
     }
 }

--- a/DropboxSync.BLL/Services/DropboxService.cs
+++ b/DropboxSync.BLL/Services/DropboxService.cs
@@ -272,10 +272,12 @@ namespace DropboxSync.BLL.Services
         }
 
         public async Task<DropboxMovedFile?> MoveFileAsync(string dropboxFileId, DateTime fileCreationDate, FileTypes movingFilesType,
-            bool isProcess, string? dossierName = null)
+            bool isProcess, string? dossierName = null, string? label = null)
         {
             if (string.IsNullOrEmpty(dropboxFileId)) throw new ArgumentNullException(nameof(dropboxFileId));
             if (string.IsNullOrEmpty(dossierName) && isProcess) throw new ArgumentNullException(nameof(dossierName));
+            if (!string.IsNullOrEmpty(label) && movingFilesType != FileTypes.Expenses)
+                throw new InvalidEnumValueException(nameof(movingFilesType));
 
             DropboxMovedFile? finalOutput = null;
 
@@ -308,11 +310,25 @@ namespace DropboxSync.BLL.Services
             {
                 if (string.IsNullOrEmpty(dossierName)) throw new NullValueException(nameof(dossierName));
 
-                newPath = GenerateDossierFolderPath(fileCreationDate.Year, dossierName, movingFilesType);
+                if (string.IsNullOrEmpty(label))
+                {
+                    newPath = GenerateDossierFolderPath(fileCreationDate.Year, dossierName, movingFilesType);
+                }
+                else
+                {
+                    newPath = GenerateLabeledExpenseDestinationPath(fileCreationDate.Year, label, dossierName);
+                }
             }
             else
             {
-                newPath = GeneratedFolderPath(fileCreationDate.Year, movingFilesType);
+                if (string.IsNullOrEmpty(label))
+                {
+                    newPath = GeneratedFolderPath(fileCreationDate.Year, movingFilesType);
+                }
+                else
+                {
+                    newPath = GenerateLabeledExpenseDestinationPath(fileCreationDate.Year, label);
+                }
             }
 
             string? verifiedPath = await VerifyFolderExist(newPath, true);

--- a/DropboxSync.BLL/Services/DropboxService.cs
+++ b/DropboxSync.BLL/Services/DropboxService.cs
@@ -658,19 +658,19 @@ namespace DropboxSync.BLL.Services
         }
 
         /// <summary>
-        /// Generate a destination path for expense based on its tag
+        /// Generate a destination path for expense based on its label
         /// </summary>
         /// <param name="year">Expense year of creation</param>
-        /// <param name="tag">Expense's tag</param>
+        /// <param name="label">Expense's label</param>
         /// <param name="dossierName">the destination dossier. If it is null or empty, the expense is sent to
         /// <c>UNPROCESSED</c> directory otherwise it is sent to the dossier</param>
         /// <returns>A Unix type folder destination path in Dropbox</returns>
         /// <exception cref="IndexOutOfRangeException"></exception>
         /// <exception cref="ArgumentNullException"></exception>
-        private string GenerateExpenseTagDestinationPath(int year, string tag, string? dossierName = null)
+        private string GenerateLabeledExpenseDestinationPath(int year, string label, string? dossierName = null)
         {
             if (year < 0) throw new IndexOutOfRangeException(nameof(year));
-            if (string.IsNullOrEmpty(tag)) throw new ArgumentNullException(nameof(tag));
+            if (string.IsNullOrEmpty(label)) throw new ArgumentNullException(nameof(label));
 
             if (string.IsNullOrEmpty(dossierName))
             {
@@ -679,7 +679,7 @@ namespace DropboxSync.BLL.Services
                     year.ToString(),
                      "UNPROCESSED",
                       FileTypes.Expenses.ToString().ToUpper(),
-                      tag.ToUpper());
+                      label.ToUpper());
             }
             else
             {
@@ -689,7 +689,7 @@ namespace DropboxSync.BLL.Services
                     FileTypes.Dossiers.ToString().ToUpper(),
                     dossierName,
                     FileTypes.Expenses.ToString().ToUpper(),
-                    tag.ToUpper());
+                    label.ToUpper());
             }
         }
 

--- a/DropboxSync.BLL/Services/DropboxService.cs
+++ b/DropboxSync.BLL/Services/DropboxService.cs
@@ -693,9 +693,9 @@ namespace DropboxSync.BLL.Services
                 return string.Join('/',
                     ROOT_FOLDER,
                     year.ToString(),
-                     "UNPROCESSED",
-                      FileTypes.Expenses.ToString().ToUpper(),
-                      label.ToUpper());
+                    "UNPROCESSED",
+                    FileTypes.Expenses.ToString().ToUpper(),
+                    label.ToUpper());
             }
             else
             {

--- a/DropboxSync.BLL/Services/DropboxService.cs
+++ b/DropboxSync.BLL/Services/DropboxService.cs
@@ -548,7 +548,7 @@ namespace DropboxSync.BLL.Services
         /// <param name="createdAt">The file's creation date</param>
         /// <param name="fileType">The type of File generated</param>
         /// <returns>
-        /// Dropbox's complete path <c> ROOT_FOLDER/YEAR/UNPROCESSED/FILETYPE </c> for Invoices and Expenses and 
+        /// Dropbox's complete path <c> ROOT_FOLDER/YEAR/UNPROCESSED/FILETYPE </c> for Invoices and Expenses and
         /// <c> ROOT_FOLDER/YEAR/DOSSIERS </c> for Dossier
         /// </returns>
         /// <exception cref="ArgumentOutOfRangeException"></exception>
@@ -614,8 +614,8 @@ namespace DropboxSync.BLL.Services
         }
 
         /// <summary>
-        /// Generate a name for the file to save in Dropbox. The name is composed of the the date and the filename seperated by 
-        /// <paramref name="seperator"/>. If at date <c>2022-10-22</c> at <c>18:42</c> a file with name <c>MyFilesName.pdf</c> 
+        /// Generate a name for the file to save in Dropbox. The name is composed of the the date and the filename seperated by
+        /// <paramref name="seperator"/>. If at date <c>2022-10-22</c> at <c>18:42</c> a file with name <c>MyFilesName.pdf</c>
         /// is created, then the generated name would look like this.
         /// <code>
         /// 2022.10.22 1842-MyFilesName.pdf
@@ -655,6 +655,42 @@ namespace DropboxSync.BLL.Services
             if (string.IsNullOrEmpty(fileName)) throw new ArgumentNullException(nameof(fileName));
 
             return string.Join('/', destinationFolderPath, fileName);
+        }
+
+        /// <summary>
+        /// Generate a destination path for expense based on its tag
+        /// </summary>
+        /// <param name="year">Expense year of creation</param>
+        /// <param name="tag">Expense's tag</param>
+        /// <param name="dossierName">the destination dossier. If it is null or empty, the expense is sent to
+        /// <c>UNPROCESSED</c> directory otherwise it is sent to the dossier</param>
+        /// <returns>A Unix type folder destination path in Dropbox</returns>
+        /// <exception cref="IndexOutOfRangeException"></exception>
+        /// <exception cref="ArgumentNullException"></exception>
+        private string GenerateExpenseTagDestinationPath(int year, string tag, string? dossierName = null)
+        {
+            if (year < 0) throw new IndexOutOfRangeException(nameof(year));
+            if (string.IsNullOrEmpty(tag)) throw new ArgumentNullException(nameof(tag));
+
+            if (string.IsNullOrEmpty(dossierName))
+            {
+                return string.Join('/',
+                    ROOT_FOLDER,
+                    year.ToString(),
+                     "UNPROCESSED",
+                      FileTypes.Expenses.ToString().ToUpper(),
+                      tag.ToUpper());
+            }
+            else
+            {
+                return string.Join('/',
+                    ROOT_FOLDER,
+                    year.ToString(),
+                    FileTypes.Dossiers.ToString().ToUpper(),
+                    dossierName,
+                    FileTypes.Expenses.ToString().ToUpper(),
+                    tag.ToUpper());
+            }
         }
 
         /// <summary>

--- a/DropboxSync.UIL/Managers/DossierManager.cs
+++ b/DropboxSync.UIL/Managers/DossierManager.cs
@@ -86,9 +86,9 @@ namespace DropboxSync.UIL.Managers
 
             _uploadService.Create(upload);
 
-            if(!_uploadService.SaveChanges())
+            if (!_uploadService.SaveChanges())
             {
-                _logger.LogError("{date} | Could not save the upload \"{uploadFileName}\" in the database!", 
+                _logger.LogError("{date} | Could not save the upload \"{uploadFileName}\" in the database!",
                 DateTime.Now, upload.OriginalFileName);
                 return false;
             }
@@ -278,7 +278,8 @@ namespace DropboxSync.UIL.Managers
 
                     DropboxMovedFile? dropboxMovedFile = AsyncHelper.RunSync(() =>
                         _dropboxService
-                            .MoveFileAsync(upload.DropboxFileId, expenseFromRepo.CreatedAt, FileTypes.Expenses, true, dossierFromRepo.Name));
+                            .MoveFileAsync(upload.DropboxFileId, expenseFromRepo.CreatedAt, FileTypes.Expenses,
+                            true, dossierFromRepo.Name, expenseFromRepo.Label));
 
                     if (dropboxMovedFile is null)
                     {
@@ -328,7 +329,7 @@ namespace DropboxSync.UIL.Managers
                 return false;
             }
 
-            DropboxMovedFile? dropboxMoveResult = AsyncHelper.RunSync(() => 
+            DropboxMovedFile? dropboxMoveResult = AsyncHelper.RunSync(() =>
                 _dropboxService
                     .MoveFileAsync(uploadFromRepo.DropboxFileId, invoiceFromRepo.CreatedAt, FileTypes.Invoices, true, dossierFromRepo.Name));
 
@@ -387,9 +388,10 @@ namespace DropboxSync.UIL.Managers
                     continue;
                 }
 
-                DropboxMovedFile? dropboxMovedFile = AsyncHelper.RunSync(() => 
+                DropboxMovedFile? dropboxMovedFile = AsyncHelper.RunSync(() =>
                     _dropboxService
-                        .MoveFileAsync(upload.DropboxFileId, expenseFromRepo.CreatedAt, FileTypes.Expenses, false));
+                        .MoveFileAsync(upload.DropboxFileId, expenseFromRepo.CreatedAt, FileTypes.Expenses,
+                        false, label: expenseFromRepo.Label));
 
                 if (dropboxMovedFile is null)
                 {
@@ -438,7 +440,7 @@ namespace DropboxSync.UIL.Managers
                 return false;
             }
 
-            DropboxMovedFile? dropboxMoveResult = AsyncHelper.RunSync(() => 
+            DropboxMovedFile? dropboxMoveResult = AsyncHelper.RunSync(() =>
                 _dropboxService
                     .MoveFileAsync(uploadFromRepo.DropboxFileId, invoiceFromRepo.CreatedAt, FileTypes.Invoices, false));
 

--- a/DropboxSync.UIL/Managers/ExpenseManager.cs
+++ b/DropboxSync.UIL/Managers/ExpenseManager.cs
@@ -235,8 +235,8 @@ namespace DropboxSync.UIL.Managers
                         continue;
                     }
 
-                    _logger.LogInformation("{date} | Upload with ID \"{uploadId}\" successfully moved to dossier \"{label}\"",
-                        DateTime.Now, upload.Id, model.Label);
+                    _logger.LogInformation("{date} | Upload with ID \"{uploadId}\" successfully moved from \"{oldPath}\" to \"{newPath}\"",
+                        DateTime.Now, upload.Id, dropboxMoveResult.OldPath, dropboxMoveResult.NewPath);
                 }
             }
 

--- a/DropboxSync.UIL/Managers/ExpenseManager.cs
+++ b/DropboxSync.UIL/Managers/ExpenseManager.cs
@@ -218,6 +218,8 @@ namespace DropboxSync.UIL.Managers
                 return false;
             }
 
+            // TODO : Move the expense to the new folder based on the label
+
             expenseFromRepo.Label = model.Label;
             expenseFromRepo.Price = model.PriceHVat;
             expenseFromRepo.Vat = model.Vat;

--- a/DropboxSync.UIL/Managers/ExpenseManager.cs
+++ b/DropboxSync.UIL/Managers/ExpenseManager.cs
@@ -218,8 +218,6 @@ namespace DropboxSync.UIL.Managers
                 return false;
             }
 
-            // TODO : Move the expense to the new folder based on the label
-
             IEnumerable<UploadEntity>? expenseUploads = _uploadService.GetExpenseRelatedUploads(expenseFromRepo.Id);
 
             if (expenseUploads is not null)

--- a/DropboxSync.UIL/Managers/ExpenseManager.cs
+++ b/DropboxSync.UIL/Managers/ExpenseManager.cs
@@ -220,6 +220,28 @@ namespace DropboxSync.UIL.Managers
 
             // TODO : Move the expense to the new folder based on the label
 
+            IEnumerable<UploadEntity>? expenseUploads = _uploadService.GetExpenseRelatedUploads(expenseFromRepo.Id);
+
+            if (expenseUploads is not null)
+            {
+                foreach (UploadEntity upload in expenseUploads)
+                {
+                    DropboxMovedFile? dropboxMoveResult = AsyncHelper.RunSync(() =>
+                        _dropboxService.MoveFileAsync(upload.DropboxFileId, expenseFromRepo.CreatedAt, FileTypes.Expenses,
+                        false, label: model.Label));
+
+                    if (dropboxMoveResult is null)
+                    {
+                        _logger.LogWarning("{date} | Could not move upload with ID \"{uploadId}\" to the dossier \"{label}\"",
+                            DateTime.Now, upload.Id, model.Label);
+                        continue;
+                    }
+
+                    _logger.LogInformation("{date} | Upload with ID \"{uploadId}\" successfully moved to dossier \"{label}\"",
+                        DateTime.Now, upload.Id, model.Label);
+                }
+            }
+
             expenseFromRepo.Label = model.Label;
             expenseFromRepo.Price = model.PriceHVat;
             expenseFromRepo.Vat = model.Vat;


### PR DESCRIPTION
## Description

When a expense's tag (label) is updated, its associated files are all moved in the right directory in Dropbox. If the expense, which the label has been uploaded is moved to a dossier, its also moved to the correct directory and finally the same goes when its removed from the dossier, it's moved back to the folder based on the label

`/ROOT_FOLDER/YEAR/UNPROCESSED/EXPENSES/LABEL_NAME/FILE_NAME`

`/ROOT_FOLDER/YEAR/DOSSIERS/DOSSIER_NAME/EXPENSES/LABEL_NAME/FILE_NAME`

Fixes #18 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Manual tests have been carried out on the app

- [x] Create expense
- [x] Modify expense's tag (label)
- [x] Add the expense to a dossier
- [x] Remove the expense from the dossier 

**Test Configuration**:
* Firmware version: Ubuntu 22.04 LTS
* Hardware: 
* Toolchain: VSCode
* SDK: .NET 6

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
