### PR TITLE
Feat/add dossier zip password

### DIFF
--- a/DropboxSync.BLL/DropboxSync.BLL.csproj
+++ b/DropboxSync.BLL/DropboxSync.BLL.csproj
@@ -1,22 +1,19 @@
 <Project Sdk="Microsoft.NET.Sdk">
-
-  <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
-  </PropertyGroup>
-
-  <ItemGroup>
-    <PackageReference Include="Dropbox.Api" Version="6.27.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="6.0.5" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="6.0.5">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-  </ItemGroup>
-
-  <ItemGroup>
-    <ProjectReference Include="..\DropboxSync.Helpers\DropboxSync.Helpers.csproj" />
-  </ItemGroup>
-
+	<PropertyGroup>
+		<TargetFramework>net6.0</TargetFramework>
+		<ImplicitUsings>enable</ImplicitUsings>
+		<Nullable>enable</Nullable>
+	</PropertyGroup>
+	<ItemGroup>
+		<PackageReference Include="Dropbox.Api" Version="6.27.0"/>
+		<PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="6.0.5"/>
+		<PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="6.0.5">
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
+		<PackageReference Include="DotNetZip" Version="1.16.0"/>
+	</ItemGroup>
+	<ItemGroup>
+		<ProjectReference Include="..\DropboxSync.Helpers\DropboxSync.Helpers.csproj"/>
+	</ItemGroup>
 </Project>

--- a/DropboxSync.BLL/IServices/IFileService.cs
+++ b/DropboxSync.BLL/IServices/IFileService.cs
@@ -10,7 +10,7 @@ namespace DropboxSync.BLL.IServices
     public record SavedFile(string RelativePath, string ContentType, string FileName, long FileSize);
     public interface IFileService
     {
-        Task<SavedFile?> DownloadFile(string fileId);
+        Task<SavedFile?> DownloadFile(string fileId, bool lockFile = false);
         bool Delete(string fileName);
     }
 }

--- a/DropboxSync.BLL/Services/FileService.cs
+++ b/DropboxSync.BLL/Services/FileService.cs
@@ -3,14 +3,8 @@ using DropboxSync.Helpers;
 using DropboxSync.BLL.IServices;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
-using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Net.Http.Headers;
-using System.Net.Http.Json;
-using System.Text;
-using System.Threading.Tasks;
+using Ionic.Zip;
 
 namespace DropboxSync.BLL.Services
 {
@@ -58,7 +52,7 @@ namespace DropboxSync.BLL.Services
         /// </summary>
         /// <param name="fileId">The ID of the file to download</param>
         /// <returns><see cref="SavedFile"/> object if download and save was successfull. <c>null</c> Otherwise</returns>
-        public async Task<SavedFile?> DownloadFile(string fileId)
+        public async Task<SavedFile?> DownloadFile(string fileId, bool lockFile)
         {
             if (string.IsNullOrEmpty(fileId)) throw new ArgumentNullException(nameof(fileId));
 
@@ -131,14 +125,45 @@ namespace DropboxSync.BLL.Services
                 return finalOutput;
             }
 
-            string filePath = Path.Join(FILE_DOWNLOAD_DIR, string.Join('-', fileId, fileName));
+            string filePath;
+            FileInfo fileInfo;
 
-            await File.WriteAllBytesAsync(filePath, fileData);
-            FileInfo fileInfo = new FileInfo(filePath);
-            if (!fileInfo.Exists)
+            if (lockFile)
             {
-                _logger.LogError("{date} | File at path \"{filePath}\" doesn't exist!", DateTime.Now, filePath);
-                return finalOutput;
+                string tmpFilePath = Path.Join(FILE_DOWNLOAD_DIR, fileName);
+                filePath = Path.Join(FILE_DOWNLOAD_DIR, string.Join('-', fileId, fileName));
+
+                await File.WriteAllBytesAsync(tmpFilePath, fileData);
+                fileInfo = new FileInfo(tmpFilePath);
+                if (!fileInfo.Exists)
+                {
+                    _logger.LogError("{date} | File at path \"{filePath}\" doesn't exist!", DateTime.Now, tmpFilePath);
+                    return finalOutput;
+                }
+
+                string zipPassword = Environment.GetEnvironmentVariable("ZIP_PASSWORD") ??
+                    "1234";
+
+                using (ZipFile zip = new ZipFile())
+                {
+                    zip.Password = zipPassword;
+                    zip.AddFile(tmpFilePath);
+                    zip.Save(filePath);
+                }
+
+                File.Delete(tmpFilePath);
+            }
+            else
+            {
+                filePath = Path.Join(FILE_DOWNLOAD_DIR, string.Join('-', fileId, fileName));
+
+                await File.WriteAllBytesAsync(filePath, fileData);
+                fileInfo = new FileInfo(filePath);
+                if (!fileInfo.Exists)
+                {
+                    _logger.LogError("{date} | File at path \"{filePath}\" doesn't exist!", DateTime.Now, filePath);
+                    return finalOutput;
+                }
             }
 
             long fileSize = fileInfo.Length;

--- a/DropboxSync.BLL/Services/FileService.cs
+++ b/DropboxSync.BLL/Services/FileService.cs
@@ -147,7 +147,7 @@ namespace DropboxSync.BLL.Services
                 using (ZipFile zip = new ZipFile())
                 {
                     zip.Password = zipPassword;
-                    zip.AddFile(tmpFilePath);
+                    zip.AddFile(tmpFilePath, "");
                     zip.Save(filePath);
                 }
 

--- a/DropboxSync.UIL/Managers/DossierManager.cs
+++ b/DropboxSync.UIL/Managers/DossierManager.cs
@@ -56,7 +56,7 @@ namespace DropboxSync.UIL.Managers
                 return false;
             }
 
-            SavedFile? localSaveResult = AsyncHelper.RunSync(() => _fileService.DownloadFile(model.UploadId));
+            SavedFile? localSaveResult = AsyncHelper.RunSync(() => _fileService.DownloadFile(model.UploadId, true));
 
             if (localSaveResult is null)
             {
@@ -86,9 +86,9 @@ namespace DropboxSync.UIL.Managers
 
             _uploadService.Create(upload);
 
-            if(!_uploadService.SaveChanges())
+            if (!_uploadService.SaveChanges())
             {
-                _logger.LogError("{date} | Could not save the upload \"{uploadFileName}\" in the database!", 
+                _logger.LogError("{date} | Could not save the upload \"{uploadFileName}\" in the database!",
                 DateTime.Now, upload.OriginalFileName);
                 return false;
             }
@@ -328,7 +328,7 @@ namespace DropboxSync.UIL.Managers
                 return false;
             }
 
-            DropboxMovedFile? dropboxMoveResult = AsyncHelper.RunSync(() => 
+            DropboxMovedFile? dropboxMoveResult = AsyncHelper.RunSync(() =>
                 _dropboxService
                     .MoveFileAsync(uploadFromRepo.DropboxFileId, invoiceFromRepo.CreatedAt, FileTypes.Invoices, true, dossierFromRepo.Name));
 
@@ -387,7 +387,7 @@ namespace DropboxSync.UIL.Managers
                     continue;
                 }
 
-                DropboxMovedFile? dropboxMovedFile = AsyncHelper.RunSync(() => 
+                DropboxMovedFile? dropboxMovedFile = AsyncHelper.RunSync(() =>
                     _dropboxService
                         .MoveFileAsync(upload.DropboxFileId, expenseFromRepo.CreatedAt, FileTypes.Expenses, false));
 
@@ -438,7 +438,7 @@ namespace DropboxSync.UIL.Managers
                 return false;
             }
 
-            DropboxMovedFile? dropboxMoveResult = AsyncHelper.RunSync(() => 
+            DropboxMovedFile? dropboxMoveResult = AsyncHelper.RunSync(() =>
                 _dropboxService
                     .MoveFileAsync(uploadFromRepo.DropboxFileId, invoiceFromRepo.CreatedAt, FileTypes.Invoices, false));
 


### PR DESCRIPTION
## Description

When a dossier is closed, the generated zip file is save in another zip file protected by a password. The file is then saved locally and in Dropbox the same way it was done before. The password is retrieved from environment variable however if the variable doesn't exist, **1234** becomes the default password.

Fixes #25 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

The tests have been carried out manually in the app.

- [x] Create a dossier
- [x] Add elements to the dossier
- [x] Close the dossier

**Test Configuration**:
* Firmware version: Ubuntu 24.04 LTS
* Hardware:
* Toolchain: VSCode
* SDK: .NET 6

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
