### PR TITLE
Bug/name duplication

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - 'main'
-      - 'develop'
 
 jobs:
   docker:

--- a/DropboxSync.BLL/Services/DropboxService.cs
+++ b/DropboxSync.BLL/Services/DropboxService.cs
@@ -191,6 +191,11 @@ namespace DropboxSync.BLL.Services
 
                 return true;
             }
+            catch (ApiException<CreateFolderError> e)
+            {
+                _logger.LogError("{date} | The Dossier folder creation failed : {e}", DateTime.Now, e.Message);
+                return false;
+            }
             catch (Exception e)
             {
                 _logger.LogError("{date} | An exception was throw during Dossier creation! : {e}",

--- a/DropboxSync.BLL/Services/DropboxService.cs
+++ b/DropboxSync.BLL/Services/DropboxService.cs
@@ -193,7 +193,8 @@ namespace DropboxSync.BLL.Services
             }
             catch (ApiException<CreateFolderError> e)
             {
-                _logger.LogError("{date} | The Dossier folder creation failed : {e}", DateTime.Now, e.Message);
+                _logger.LogError("{date} | The Dossier folder creation failed, please use another name : {e}",
+                    DateTime.Now, e.Message);
                 return false;
             }
             catch (Exception e)

--- a/DropboxSync.UIL/BrokerEventListener.cs
+++ b/DropboxSync.UIL/BrokerEventListener.cs
@@ -229,16 +229,6 @@ namespace DropboxSync.UIL
                         SendToFailedQueue(textMessage, brokerEvent);
                     }
 
-                    // if (EventRedirection(brokerEvent, textMessage))
-                    // {
-                    //     // When a message is successfully treated, a ACK is sent to notify the broker
-                    //     _logger.LogInformation("{date} | Event {eventName} treated with success!", DateTime.Now, eventModel.EventName);
-                    // }
-                    // else
-                    // {
-                    //     SendToFailedQueue(textMessage, brokerEvent);
-                    // }
-
                     receiver.Accept(message);
                 }
             }
@@ -341,7 +331,6 @@ namespace DropboxSync.UIL
 
                 BrokerEvent eventType = (BrokerEvent)brokerEventParseResult;
 
-                // bool redirectionResult = Task.Run<bool>(() => EventRedirection(eventType, failedEvent.MessageJson)).Result;
                 bool redirectionResult = Task.Run<bool>(() =>
                     _eventManagerLocator.RedirectToManager(failedEvent.MessageJson)).Result;
 


### PR DESCRIPTION
## Description

When a new dossier with the same name as a previously one is created, the service throws an exception and the service is blocked. To overpass that I added a simple try catch, catching the right exception and simply logging to user to chose a new name

Fixes #21 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

**Test Configuration**:
* Firmware version: Ubuntu 22.04 LTS
* Hardware:
* Toolchain: VSCode
* SDK: .NET 6

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
